### PR TITLE
Update gitlab for api v4.

### DIFF
--- a/lib/gitspindle/gitlab.py
+++ b/lib/gitspindle/gitlab.py
@@ -140,8 +140,8 @@ class GitLab(GitSpindle):
             return self.gl._url
         host = self.config('host')
         if not host:
-            return 'https://gitlab.com/api/v3'
-        host = host.rstrip('/') + '/api/v3'
+            return 'https://gitlab.com/api/v4'
+        host = host.rstrip('/') + '/api/v4'
         if not host.startswith(('http://', 'https://')):
             host = 'https://' + host
         return host


### PR DESCRIPTION
Fixed error gitspindle.glapi.GitlabAuthenticationError: 410: {"error":"API V3 is no longer supported. Use API V4 instead."}

it was necessary to update the api to version 4.